### PR TITLE
Add requirements.txt to MANIFEST.in to fix installation with easy_install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.markdown
+include requirements.txt
 include test.py


### PR DESCRIPTION
This is the fast fix for the problem with easy_install: it's unable to use easy_install (or buildout, pip doesn't have such problem) to get your package installed from pypi:
```
error: [Errno 2] No such file or directory: '/tmp/easy_install-Bvx3Sj/pyotp-2.0.0/requirements.txt'
```

But the right way is to remove reading of `requirements.txt` from [setup.py:6](https://github.com/pyotp/pyotp/blob/ff259e9cad34d099057179ed7333a00b5e87cdea/setup.py#L6)
Now it's empty, but if someone will add comment or ``-r another_file.txt`` to requirements.txt it'll be broken.
