### PR TITLE
Fix python base32 "TypeError: Incorrect padding"

### DIFF
--- a/src/pyotp/otp.py
+++ b/src/pyotp/otp.py
@@ -46,6 +46,9 @@ class OTP(object):
         return str_code
 
     def byte_secret(self):
+        missing_padding = len(self.secret) % 8
+        if missing_padding != 0:
+            self.secret += '=' * (8 - missing_padding)
         return base64.b32decode(self.secret, casefold=True)
 
     @staticmethod

--- a/test.py
+++ b/test.py
@@ -49,6 +49,13 @@ class HOTPExampleValuesFromTheRFC(unittest.TestCase):
         self.assertEqual(
             hotp.provisioning_uri('mark@percival', issuer_name='FooCorp!'),
             'otpauth://hotp/FooCorp%21:mark@percival?secret=wrn3pqx5uqxqvnqr&counter=0&issuer=FooCorp%21')
+    def testOtherSecret(self):
+        hotp = pyotp.HOTP('N3OVNIBRERIO5OHGVCMDGS4V4RJ3AUZOUN34J6FRM4P6JIFCG3ZA')
+        self.assertEqual(hotp.at(0), '737863')
+        self.assertEqual(hotp.at(1), '390601')
+        self.assertEqual(hotp.at(2), '363354')
+        self.assertEqual(hotp.at(3), '936780')
+        self.assertEqual(hotp.at(4), '654019')
 
 
 class TOTPExampleValuesFromTheRFC(unittest.TestCase):


### PR DESCRIPTION
Signed-off-by: Kun Yan <kyan@redhat.com>

Python base32 will throw error when input secret like this
```python
import base64
secret = r'N3OVNIBRERIO5OHGVCMDGS4V4RJ3AUZOUN34J6FRM4P6JIFCG3ZA'
print base64.b32decode(secret, casefold=True)
```

output:

```bash
Traceback (most recent call last):
  File "<string>", line 3, in <module>
  File "/usr/lib64/python2.7/base64.py", line 198, in b32decode
    raise TypeError('Incorrect padding')
TypeError: Incorrect padding
```