### PR TITLE
Don't reveal string length to attacker.

### DIFF
--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -1,6 +1,10 @@
 from __future__ import print_function, unicode_literals, division, absolute_import
 
 import unicodedata
+try:
+    from itertools import izip_longest
+except ImportError:
+    from itertools import zip_longest as izip_longest
 
 try:
     from urllib.parse import quote
@@ -77,6 +81,6 @@ def strings_equal(s1, s2):
         return False
 
     differences = 0
-    for c1, c2 in zip(s1, s2):
+    for c1, c2 in izip_longest(s1, s2, '\0'):
         differences |= ord(c1) ^ ord(c2)
     return differences == 0

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -55,6 +55,20 @@ def build_uri(secret, name, initial_count=None, issuer_name=None):
 
     return uri
 
+try:
+    # Python 3.3+ and 2.7.7+ include a timing-attack-resistant
+    # comparison function, which is probably more reliable than ours.
+    # Use it if available.
+    from hmac import compare_digest
+
+except ImportError:
+    def compare_digest(s1, s2):
+        differences = 0
+        for c1, c2 in izip_longest(s1, s2):
+            if c1 is None or c2 is None:
+                continue
+            differences |= ord(c1) ^ ord(c2)
+        return differences == 0
 
 def strings_equal(s1, s2):
     """
@@ -67,19 +81,4 @@ def strings_equal(s1, s2):
     """
     s1 = unicodedata.normalize('NFKC', s1)
     s2 = unicodedata.normalize('NFKC', s2)
-    try:
-        # Python 3.3+ and 2.7.7+ include a timing-attack-resistant
-        # comparison function, which is probably more reliable than ours.
-        # Use it if available.
-        from hmac import compare_digest
-
-        return compare_digest(s1, s2)
-    except ImportError:
-        pass
-
-    differences = 0
-    for c1, c2 in izip_longest(s1, s2):
-        if c1 is None or c2 is None:
-            continue
-        differences |= ord(c1) ^ ord(c2)
-    return differences == 0
+    return compare_digest(s1, s2)

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -55,6 +55,16 @@ def build_uri(secret, name, initial_count=None, issuer_name=None):
 
     return uri
 
+
+def _compare_digest(s1, s2):
+    differences = 0
+    for c1, c2 in izip_longest(s1, s2):
+        if c1 is None or c2 is None:
+            differences = 1
+            continue
+        differences |= ord(c1) ^ ord(c2)
+    return differences == 0
+
 try:
     # Python 3.3+ and 2.7.7+ include a timing-attack-resistant
     # comparison function, which is probably more reliable than ours.
@@ -62,14 +72,8 @@ try:
     from hmac import compare_digest
 
 except ImportError:
-    def compare_digest(s1, s2):
-        differences = 0
-        for c1, c2 in izip_longest(s1, s2):
-            if c1 is None or c2 is None:
-                differences = 1
-                continue
-            differences |= ord(c1) ^ ord(c2)
-        return differences == 0
+    compare_digest = _compare_digest
+
 
 def strings_equal(s1, s2):
     """

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -80,6 +80,6 @@ def strings_equal(s1, s2):
     differences = 0
     for c1, c2 in izip_longest(s1, s2):
         if c1 is None or c2 is None:
-            pass
+            continue
         differences |= ord(c1) ^ ord(c2)
     return differences == 0

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -66,6 +66,7 @@ except ImportError:
         differences = 0
         for c1, c2 in izip_longest(s1, s2):
             if c1 is None or c2 is None:
+                differences = 1
                 continue
             differences |= ord(c1) ^ ord(c2)
         return differences == 0

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -77,9 +77,6 @@ def strings_equal(s1, s2):
     except ImportError:
         pass
 
-    if len(s1) != len(s2):
-        return False
-
     differences = 0
     for c1, c2 in izip_longest(s1, s2, '\0'):
         differences |= ord(c1) ^ ord(c2)

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -78,6 +78,8 @@ def strings_equal(s1, s2):
         pass
 
     differences = 0
-    for c1, c2 in izip_longest(s1, s2, '\0'):
+    for c1, c2 in izip_longest(s1, s2):
+        if c1 is None or c2 is None:
+            pass
         differences |= ord(c1) ^ ord(c2)
     return differences == 0

--- a/test.py
+++ b/test.py
@@ -137,18 +137,30 @@ class TOTPExampleValuesFromTheRFC(unittest.TestCase):
         self.assertEqual(len(pyotp.random_base32()), 16)
         self.assertEqual(len(pyotp.random_base32(length=20)), 20)
 
-class StringComparisonTest(unittest.TestCase):
-    def test_comparisons(self):
-        self.assertTrue(pyotp.utils.strings_equal("", ""))
-        self.assertTrue(pyotp.utils.strings_equal("a", "a"))
-        self.assertTrue(pyotp.utils.strings_equal("a" * 1000, "a" * 1000))
 
-        self.assertFalse(pyotp.utils.strings_equal("", "a"))
-        self.assertFalse(pyotp.utils.strings_equal("a", ""))
-        self.assertFalse(pyotp.utils.strings_equal("a" * 999 + "b", "a" * 1000))
+class CompareDigestTest(unittest.TestCase):
+    method = staticmethod(pyotp.utils.compare_digest)
+
+    def test_comparisons(self):
+        self.assertTrue(self.method("", ""))
+        self.assertTrue(self.method("a", "a"))
+        self.assertTrue(self.method("a" * 1000, "a" * 1000))
+
+        self.assertFalse(self.method("", "a"))
+        self.assertFalse(self.method("a", ""))
+        self.assertFalse(self.method("a" * 999 + "b", "a" * 1000))
+
+
+class FallBackCompareDigestTest(CompareDigestTest):
+    method = staticmethod(pyotp.utils._compare_digest)
+
+
+class StringComparisonTest(CompareDigestTest):
+    method = staticmethod(pyotp.utils.strings_equal)
 
     def test_fullwidth_input(self):
-        self.assertTrue(pyotp.utils.strings_equal("ｘs１２３45", "xs12345"))
+        self.assertTrue(self.method("ｘs１２３45", "xs12345"))
+
 
 class CounterOffsetTest(unittest.TestCase):
     def test_counter_offset(self):


### PR DESCRIPTION
Instead of terminating at the shortest string, terminate at the longest string.