### PR TITLE
Correct provisioning_uri method's output

### DIFF
--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -1,4 +1,5 @@
-from __future__ import print_function, unicode_literals, division, absolute_import
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
 
 import random as _random
 
@@ -6,6 +7,7 @@ from pyotp.hotp import HOTP  # noqa
 from pyotp.otp import OTP  # noqa
 from pyotp.totp import TOTP  # noqa
 from . import utils  # noqa
+
 
 def random_base32(length=16, random=_random.SystemRandom(),
                   chars=list('ABCDEFGHIJKLMNOPQRSTUVWXYZ234567')):

--- a/src/pyotp/hotp.py
+++ b/src/pyotp/hotp.py
@@ -1,8 +1,10 @@
-from __future__ import print_function, unicode_literals, division, absolute_import
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
 
 from pyotp.otp import OTP
 from pyotp import utils
 from future.builtins import str
+
 
 class HOTP(OTP):
     def at(self, count):

--- a/src/pyotp/hotp.py
+++ b/src/pyotp/hotp.py
@@ -37,4 +37,6 @@ class HOTP(OTP):
             name,
             initial_count=initial_count,
             issuer_name=issuer_name,
+            algorithm=self.digest().name,
+            digits=self.digits
         )

--- a/src/pyotp/otp.py
+++ b/src/pyotp/otp.py
@@ -1,9 +1,11 @@
-from __future__ import print_function, unicode_literals, division, absolute_import
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
 
 import base64
 import hashlib
 import hmac
 from future.builtins import str
+
 
 class OTP(object):
     def __init__(self, s, digits=6, digest=hashlib.sha1):
@@ -62,6 +64,7 @@ class OTP(object):
         while i != 0:
             result.append(i & 0xFF)
             i >>= 8
-        # It's necessary to convert the final result from bytearray to bytes because
-        # the hmac functions in python 2.6 and 3.3 don't work with bytearray
+        # It's necessary to convert the final result from bytearray to bytes
+        # because the hmac functions in python 2.6 and 3.3 don't work with
+        # bytearray
         return bytes(bytearray(reversed(result)).rjust(padding, b'\0'))

--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -1,4 +1,5 @@
-from __future__ import print_function, unicode_literals, division, absolute_import
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
 
 import datetime
 import time
@@ -6,6 +7,7 @@ import time
 from pyotp import utils
 from pyotp.otp import OTP
 from future.builtins import str
+
 
 class TOTP(OTP):
     def __init__(self, *args, **kwargs):
@@ -21,7 +23,8 @@ class TOTP(OTP):
         Accepts either a Unix timestamp integer or a Time object.
         Time objects will be adjusted to UTC automatically
         @param [Time/Integer] time the time to generate an OTP for
-        @param [Integer] counter_offset an amount of ticks to add to the time counter
+        @param [Integer] counter_offset an amount of ticks to add to the time
+            counter
         """
         if not isinstance(for_time, datetime.datetime):
             for_time = datetime.datetime.fromtimestamp(int(for_time))
@@ -38,7 +41,8 @@ class TOTP(OTP):
         """
         Verifies the OTP passed in against the current time OTP
         @param [String/Integer] otp the OTP to check against
-        @param [Integer] valid_window extends the validity to this many counter ticks before and after the current one
+        @param [Integer] valid_window extends the validity to this many counter
+            ticks before and after the current one
         """
         if for_time is None:
             for_time = datetime.datetime.now()

--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -59,7 +59,9 @@ class TOTP(OTP):
         @param [String] name of the account
         @return [String] provisioning uri
         """
-        return utils.build_uri(self.secret, name, issuer_name=issuer_name)
+        return utils.build_uri(self.secret, name, issuer_name=issuer_name,
+                               algorithm=self.digest().name,
+                               digits=self.digits, period=self.interval)
 
     def timecode(self, for_time):
         i = time.mktime(for_time.timetuple())

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -1,4 +1,5 @@
-from __future__ import print_function, unicode_literals, division, absolute_import
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
 
 import unicodedata
 try:
@@ -9,7 +10,8 @@ except ImportError:
 try:
     from urllib.parse import quote, urlencode
 except ImportError:
-    from urllib import quote
+    from urllib import quote, urlencode
+
 
 def build_uri(secret, name, initial_count=None, issuer_name=None,
               algorithm=None, digits=None, period=None):
@@ -22,7 +24,7 @@ def build_uri(secret, name, initial_count=None, issuer_name=None,
     For module-internal use.
 
     See also:
-        http://code.google.com/p/google-authenticator/wiki/KeyUriFormat
+        https://github.com/google/google-authenticator/wiki/Key-Uri-Format
 
     @param [String] the hotp/totp secret used to generate the URI
     @param [String] name of the account
@@ -30,6 +32,10 @@ def build_uri(secret, name, initial_count=None, issuer_name=None,
         If none, the OTP type will be assumed as TOTP.
     @param [String] the name of the OTP issuer; this will be the
         organization title of the OTP entry in Authenticator
+    @param [String] the algorithm used in the OTP generation.
+    @param [Integer] the length of the OTP generated code.
+    @param [Integer] the number of seconds the OTP generator is set to
+        expire every code.
     @return [String] provisioning uri
     """
     # initial_count may be 0 as a valid param
@@ -57,7 +63,7 @@ def build_uri(secret, name, initial_count=None, issuer_name=None,
     if is_digits_set:
         url_args['digits'] = digits
     if is_period_set:
-       url_args['period'] = period
+        url_args['period'] = period
 
     uri = base_uri.format(otp_type, label, urlencode(url_args))
     return uri


### PR DESCRIPTION
Added to the provisioning_uri method in HOTP and TOTP classes the
ability to call the util's function build_uri with all the necessary
arguments.

Added to the function build_uri the ability to handle values different
than the defaults for algorithm, digits and period when generating URI.

Closes #32