### PR TITLE
valid_window checks equal # of windows before/after

### DIFF
--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -45,7 +45,7 @@ class TOTP(OTP):
             for_time = datetime.datetime.now()
 
         if valid_window:
-            for i in range(-valid_window, valid_window + 1):
+            for i in range(-valid_window, valid_window + 2):
                 if utils.strings_equal(str(otp), str(self.at(for_time, i))):
                     return True
             return False


### PR DESCRIPTION
The docstring for the `valid_window` parameter of `TOTP.verify()` currently
reads:

```
@param [Integer] valid_window extends the validity to this many counter
    ticks before and after the current one
```

It is sensible one would want to include future windows to account for the case
where a client and server clock are slightly out of sync. The old code would
extend the validity to one less than valid_window ticks because of the
upper-bound exclusivity property of `range` (`[lower, upper)`). This fixes that
and brings it in line with the docstring spec.