### PR TITLE
Improve constant-time comparison by avoiding short-circuiting

### DIFF
--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -45,10 +45,11 @@ class TOTP(OTP):
             for_time = datetime.datetime.now()
 
         if valid_window:
+            valid = False
             for i in range(-valid_window, valid_window + 1):
-                if utils.strings_equal(str(otp), str(self.at(for_time, i))):
-                    return True
-            return False
+                valid = utils.strings_equal(str(otp),
+                                            str(self.at(for_time, i))) | valid
+            return valid
 
         return utils.strings_equal(str(otp), str(self.at(for_time)))
 

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -74,7 +74,7 @@ def _compare_digest(s1, s2):
         if c1 is None or c2 is None:
             differences = 1
             continue
-        differences |= ord(c1) ^ ord(c2)
+        differences = ord(c1) ^ ord(c2) | differences
     return differences == 0
 
 try:


### PR DESCRIPTION
This PR improves constant-time verification for the functions
`utils._compare_digest()` and `totp.verify()`.

In the old `util._compare_digest()`, once a comparison returns a non-zero value
the loop continues, but short-circuits before evaluating all the comparisons
that should follow. By writing `ord(c1) ^ ord(c2) | differences` instead of
`difference | ord(c1) ^ ord(c2)` (which is what `|=` is syntactic sugar for), we
actually evaluate the XOR expression each loop for equal-length strings.

In the old `totp.verify()`, when `valid_window` is specified, the verification
will short-circuit if for any window the OTP is valid. In the case that an
adversary enters a valid username and OTP for that user, but not a valid
password, it seems reasonable that we don't want to leak that the OTP was valid.