### PR TITLE
Change random to secrets

### DIFF
--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
-import random as _random
+import secrets as _random
 
 from pyotp.hotp import HOTP  # noqa
 from pyotp.otp import OTP  # noqa


### PR DESCRIPTION
The random module isn't for security purposes. Change to secrets module.

> Warning The pseudo-random generators of this module should not be used for security purposes. For security or cryptographic uses, see the secrets module.

[https://docs.python.org/3.6/library/random.html](https://docs.python.org/3.6/library/random.html)