### PR TITLE
Fix for double URL encoding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,11 +70,11 @@ ability to generate provisioning URIs for use with the QR Code scanner built int
 
     pyotp.totp.TOTP('JBSWY3DPEHPK3PXP').provisioning_uri("alice@google.com", issuer_name="Secure App")
 
-    >>> 'otpauth://totp/Secure%20App:alice%40google.com?secret=JBSWY3DPEHPK3PXP&issuer=Secure+App'
+    >>> 'otpauth://totp/Secure%20App:alice%40google.com?secret=JBSWY3DPEHPK3PXP&issuer=Secure%20App'
 
     pyotp.hotp.HOTP('JBSWY3DPEHPK3PXP').provisioning_uri("alice@google.com", initial_count=0, issuer_name="Secure App")
 
-    >>> 'otpauth://hotp/Secure%20App:alice%40google.com?secret=JBSWY3DPEHPK3PXP&issuer=Secure+App&counter=0'
+    >>> 'otpauth://hotp/Secure%20App:alice%40google.com?secret=JBSWY3DPEHPK3PXP&issuer=Secure%20App&counter=0'
 
 This URL can then be rendered as a QR Code (for example, using https://github.com/neocotic/qrious) which can then be scanned
 and added to the users list of OTP credentials.

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -61,7 +61,7 @@ def build_uri(secret, name, initial_count=None, issuer_name=None,
     label = quote(name)
     if issuer_name is not None:
         label = quote(issuer_name) + ':' + label
-        url_args['issuer'] = quote(issuer_name)
+        url_args['issuer'] = issuer_name
 
     if is_initial_count_present:
         url_args['counter'] = initial_count
@@ -72,7 +72,7 @@ def build_uri(secret, name, initial_count=None, issuer_name=None,
     if is_period_set:
         url_args['period'] = period
 
-    uri = base_uri.format(otp_type, label, urlencode(url_args))
+    uri = base_uri.format(otp_type, label, urlencode(url_args, quote_via=quote))
     return uri
 
 


### PR DESCRIPTION
In the latest version (2.2.5) the pyotp method for provisioning URI's current double-escapes the inputted `issuer_name` parameter.

![double-encoding](https://cloud.githubusercontent.com/assets/9205510/26756930/d92009b8-4872-11e7-8110-2983429e947d.PNG)

To fix this, the original `quote()` method applied to the `issuer_name` was removed, and instead, the later used `urlencode()` method now has a parameter instructing it to ignore its default encoding scheme (`+` to escape spaces) and instead use the `urllib.parse.quote()` method (which uses `%20` to encode spaces).

See issue #47.