### PR TITLE
Secret stripper

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 
 setup(
     name="pyotp",
-    version="2.2.6",
+    version="2.2.7",
     url="https://github.com/pyotp/pyotp",
     license="BSD License",
     author="PyOTP contributors",

--- a/src/pyotp/otp.py
+++ b/src/pyotp/otp.py
@@ -20,6 +20,8 @@ class OTP(object):
         """
         self.digits = digits
         self.digest = digest
+        if type(s) == str:  # Avoids ERROR: test_match_rfc AttributeError: 'int' object has no attribute 'upper'
+            s = ''.join(c for c in s if c.upper() in "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567=")
         self.secret = s
 
     def generate_otp(self, input):


### PR DESCRIPTION
Added function that strips secret string from all non base32 characters.  As many Two-step-verification providers tend to show the secrets this way, i.e. `"JBSW Y3DP EHPK 3PXP"` instead of `"JBSWY3DPEHPK3PXP"`
This feature make pyotp way easier to use with the console.

Fixed pull request [#54](https://github.com/pyotp/pyotp/pull/54) issues:
```
src/pyotp/otp.py:23:27: E261 at least two spaces before inline comment
src/pyotp/otp.py:23:121: E501 line too long (150 > 120 characters)
```
