### PR TITLE
Have random_base32() use 'secrets' as rand source

### DIFF
--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -1,16 +1,23 @@
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
-import random as _random
-
 from pyotp.hotp import HOTP  # noqa
 from pyotp.otp import OTP  # noqa
 from pyotp.totp import TOTP  # noqa
 from . import utils  # noqa
 
-
-def random_base32(length=16, random=_random.SystemRandom(),
+def random_base32(length=16, random=None,
                   chars=list('ABCDEFGHIJKLMNOPQRSTUVWXYZ234567')):
+    
+    # Use secrets module if available (Python version >= 3.6) per PEP 506
+    try:
+        import secrets
+    except ImportError:
+        import random as _random
+        random = _random.SystemRandom()
+    else:
+        random = secrets.SystemRandom()
+
     return ''.join(
         random.choice(chars)
         for _ in range(length)


### PR DESCRIPTION
In PEP 506 https://www.python.org/dev/peps/pep-0506/ it's recommended (suggested) that "(...) secrets becomes the go-to module for dealing with anything which should remain secret (passwords, tokens, etc.) (...)"

secrets was included in python 3.6. This update will use secrets providing the most secure way to generate the token if secrets is available, and will default to random if not.